### PR TITLE
Update URL to OAuth 1

### DIFF
--- a/lib/edit/init_credentials.js
+++ b/lib/edit/init_credentials.js
@@ -64,7 +64,7 @@ const prefilledParams = [
   'wpownerOnly=1'
 ].join('&')
 
-const oauthConsumerRegistrationPathname = `/wiki/Special:OAuthConsumerRegistration/propose?${prefilledParams}`
+const oauthConsumerRegistrationPathname = `/wiki/Special:OAuthConsumerRegistration/propose/oauth1a?${prefilledParams}`
 const getOAuthConsumerRegistrationUrl = instance => {
   if (instance.endsWith('wikidata.org')) return `https://meta.wikimedia.org${oauthConsumerRegistrationPathname}`
   else return `${instance}${oauthConsumerRegistrationPathname}`


### PR DESCRIPTION
The previous URL would make you choose between OAuth 1 and OAuth2, and also discard the parameters. This fixes the link so it uses OAuth v1 and keeps the parameters.